### PR TITLE
소환사 레벨 및 엠블럼 이미지 구현

### DIFF
--- a/server/proxyServer.js
+++ b/server/proxyServer.js
@@ -8,7 +8,16 @@ const app = express();
 app.use(cors());
 
 // API key
-const API_KEY = "RGAPI-31d4d76d-d4dd-4ae6-a8d6-089d68a618e0";
+const API_KEY = "RGAPI-3c668432-cc17-45f4-a461-3137a00e3433";
+
+// 소환사의 puuid값을 가져오는 함수
+const getPlayerInformation = (playerName) => {
+    return axios.get(`https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/${playerName}?api_key=${API_KEY}`)
+        .then(response => {
+            return response.data;
+        })
+        .catch((error) => console.log(error));
+}
 
 // 소환사의 puuid값을 가져오는 함수
 const getPlayerPUUID = (playerName) => {
@@ -29,6 +38,17 @@ const getPlayerID = (playerName) => {
     })
     .catch((error) => console.log(error));
 }
+
+// GET information (소환사 정보 가져오기)
+// localhost:4000/information
+app.get('/information', async (req, res) => {
+    const playerName = req.query.searchText;
+
+    // information (소환사 정보 얻어오기)
+    const information = await getPlayerInformation(playerName);
+
+    res.json(information); 
+})
 
 // GET past5Games (과거 5게임 가져오기)
 // localhost:4000/past5Games

--- a/server/proxyServer.js
+++ b/server/proxyServer.js
@@ -10,7 +10,7 @@ app.use(cors());
 // API key
 const API_KEY = "RGAPI-3c668432-cc17-45f4-a461-3137a00e3433";
 
-// 소환사의 puuid값을 가져오는 함수
+// 소환사 정보를 가져오는 함수
 const getPlayerInformation = (playerName) => {
     return axios.get(`https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/${playerName}?api_key=${API_KEY}`)
         .then(response => {

--- a/src/App.js
+++ b/src/App.js
@@ -7,8 +7,18 @@ import championData from "./Data/Champions/ChampionData.js";
 
 function App() {
   const [searchText, setSearchText] = useState(''); // 검색문자열
+  const [information, setInformation] = useState([]); // 소환사 정보가 들어갈 Array
   const [gameList, setGameList] = useState([]); // 매치정보가 들어갈 Array
   const [leagueList, setLeagueList] = useState([]); // 소환사 리그정보(티어정보)가 들어갈 Array
+
+  // 소환사 정보를 가져오는 함수
+  const getPlayerInformation = (e) => {
+    axios.get('http://localhost:4000/information', {params : {searchText : searchText}})
+      .then((response) => {
+        setInformation(response.data);
+      })
+      .catch((error) => console.log(error));
+  }
 
   // 매치정보를 가져오는 함수
   const getPlayerGames = (e) => {
@@ -28,6 +38,7 @@ function App() {
       .catch((error) => console.log(error));
   }
 
+  console.log(information, "information"); // 소환사 정보
   console.log(gameList, "gameList"); // 매치 정보
   console.log(leagueList, "leagueList") // 소환사 리그정보(티어정보)
   console.log(championData, "championData"); // 챔피언데이터가 들어있는 Array
@@ -49,11 +60,12 @@ function App() {
         <button onClick={() => {
           getPlayerGames();
           getPlayerLeague();
+          getPlayerInformation();
         }} className={styles['app-searchButton']} >
           <FcSearch className={styles['app-searchButton-icons']}/>
         </button>
       </div>
-      <Match gameList={gameList} searchText={searchText} leagueList={leagueList}/>
+      <Match information={information} gameList={gameList} searchText={searchText} leagueList={leagueList}/>
     </div>
   );
 }

--- a/src/components/Match.js
+++ b/src/components/Match.js
@@ -3,7 +3,7 @@ import styles from "./Match.module.css";
 import SummonerProfile from "./SummonerProfile";
 
 // 매치기록 컴포넌트
-const Match = ({ gameList, searchText, leagueList }) => {
+const Match = ({ information, gameList, searchText, leagueList }) => {
 
     return (
         <>
@@ -13,7 +13,7 @@ const Match = ({ gameList, searchText, leagueList }) => {
                     gameList.length !== 0 ? 
                     <>
                         <h3 className={styles["gameData-title"]}>검색결과</h3>
-                        <SummonerProfile gameList={gameList} searchText={searchText} leagueList={leagueList} />
+                        <SummonerProfile information={information} gameList={gameList} searchText={searchText} leagueList={leagueList} />
                         {
                             gameList.map((gameData, index) => (
     

--- a/src/components/SummonerProfile.js
+++ b/src/components/SummonerProfile.js
@@ -1,24 +1,52 @@
 import React, { useEffect, useState } from "react";
 import styles from "./SummonerProfile.module.css";
+import Emblem_Iron from "./../Data/Emblems/Emblem_Iron.png"
+import Emblem_Bronze from "./../Data/Emblems/Emblem_Bronze.png"
+import Emblem_Silver from "./../Data/Emblems/Emblem_Silver.png"
+import Emblem_Gold from "./../Data/Emblems/Emblem_Gold.png"
+import Emblem_Platinum from "./../Data/Emblems/Emblem_Platinum.png"
+import Emblem_Diamond from "./../Data/Emblems/Emblem_Diamond.png"
+import Emblem_Master from "./../Data/Emblems/Emblem_Master.png"
+import Emblem_Grandmaster from "./../Data/Emblems/Emblem_Grandmaster.png"
+import Emblem_Challenger from "./../Data/Emblems/Emblem_Challenger.png"
 
 // 소환사 프로필 컴포넌트
-const SummonerProfile = ({ gameList, searchText, leagueList }) => {
+const SummonerProfile = ({ information, gameList, searchText, leagueList }) => {
+    const emblemImgs = [{key : "IRON", Emblem : Emblem_Iron}, {key : "BRONZE", Emblem : Emblem_Bronze}, 
+        {key : "SILVER", Emblem : Emblem_Silver}, {key : "GOLD", Emblem : Emblem_Gold},
+        {key : "PLATINUM", Emblem : Emblem_Platinum}, {key : "DIAMOND", Emblem : Emblem_Diamond},
+        {key : "MASTER", Emblem : Emblem_Master}, {key : "GRNADMASTER", Emblem : Emblem_Grandmaster}, 
+        {key : "CHALLENGER", Emblem : Emblem_Challenger}];
     
     return (
         <>
             <div className={styles['summonerProfile-container']}>
                 <div className={styles['summonerProfile-profile']}>
                     <h3 id={styles["summonerName"]}>{leagueList[0][0]?.summonerName}</h3>
-                    <h4 id={styles["summonerLevel"]}>level </h4>
+                    <h4 id={styles["summonerLevel"]}>level {information.summonerLevel}</h4>
                 </div>
-                <div className={styles['summonerProfile-lankInfo']}>
+                <div className={styles['summonerProfile-lankInfo']}>                     
                     <ul className={styles['summonerProfile-soloLank']}>
+                        {emblemImgs.map(list => {
+                            if(list.key == leagueList[0][0]?.tier) {
+                                return (
+                                    <li><img src={list.Emblem} className={styles['emblemImg']}/></li>
+                                )
+                            }
+                        })}
                         <li>리그 : 솔로랭크 5X5</li>
                         <li>티어 : {leagueList[0][0]?.tier} {leagueList[0][0]?.rank}</li>
                         <li>리그 포인트 : {leagueList[0][0]?.leaguePoints}</li>
                         <li>{leagueList[0][0]?.wins + leagueList[0][0]?.losses}전 {leagueList[0][0]?.wins}승 {leagueList[0][0]?.losses}패</li>
                     </ul>
                     <ul className={styles['summonerProfile-freeLank']}>
+                        {emblemImgs.map(list => {
+                            if(list.key == leagueList[0][1]?.tier) {
+                                return (
+                                    <li><img src={list.Emblem} className={styles['emblemImg']}/></li>
+                                )
+                            }
+                        })}
                         <li>리그 : 자유랭크 5X5</li>
                         <li>티어 : {leagueList[0][1]?.tier} {leagueList[0][1]?.rank}</li>
                         <li>리그 포인트 : {leagueList[0][1]?.leaguePoints}</li>

--- a/src/components/SummonerProfile.module.css
+++ b/src/components/SummonerProfile.module.css
@@ -56,3 +56,9 @@
     font-size: 15px;
     list-style: none;
 }
+
+.emblemImg {
+    width: 70px;
+    height: 70px;
+    text-align: center;
+}


### PR DESCRIPTION
1. 소환사 레벨 구현

- proxyServer에서 소환사 정보를 받아서 information에 저장하고, Match 컴포넌트와 SummonerProfile 컴포넌트에 차례대로 props값으로 information을 보냄.
- information.summonerLevel을 통해 검색된 소환사의 레벨이 보이도록 구현.

2. 엠블럼 이미지 구현

- SummonerProfile 컴포넌트에 엠블럼 이미지들을 import 시킴.
- emblemImgs 배열에 엠블럼 이미지들을 key값(티어 문자열 ex) "BRONZE")과 같이 저장.
- emblemImgs 배열의 원소들의 key값과 검색된 소환사의 티어를 비교, 맞으면 해당 엠블렘이 이미지로 나오게 구현.

![image](https://user-images.githubusercontent.com/80691239/199929073-ebdf58ad-c651-4aac-9710-cc8a4a012778.png)
