### PR TITLE
매치 기록의 킬관여 및 승패에 따른 배경색 구현

### DIFF
--- a/server/proxyServer.js
+++ b/server/proxyServer.js
@@ -8,7 +8,7 @@ const app = express();
 app.use(cors());
 
 // API key
-const API_KEY = "RGAPI-5a0b1db0-8312-4919-8367-71564ae21c5c";
+const API_KEY = "RGAPI-33297b64-e1cf-44e6-86c3-f226c03a8519";
 
 // 소환사 정보를 가져오는 함수
 const getPlayerInformation = (playerName) => {

--- a/src/components/contents/Match.js
+++ b/src/components/contents/Match.js
@@ -1,10 +1,38 @@
-import React from "react";
+import React, { useState } from "react";
 import styles from "./Match.module.css";
 import SummonerProfile from "./SummonerProfile";
 
 // 매치기록 컴포넌트
 const Match = ({ information, gameList, searchText, leagueList, profileIconID }) => {
+    // 소환사가 속한 팀의 teamId들을 저장할 summonerTeamIdsOfGamelist 배열 생성
+    // 소환사가 속한 팀의 전체 킬 수들을 저장할 killsOfGamelist 배열 생성
+    // 소환사가 속한 팀의 승리 여부들을 저장할 summonerTeamIsWin 배열 생성
+    const summonerTeamIdsOfGamelist = [];
+    const killsOfGamelist = [];
+    const summonerTeamIsWin = [];
 
+    gameList.map((gameData) => (
+        gameData.info.participants.map(participant => {
+            // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우 
+            if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
+                // 검색된 소환사의 teamId를 summonerTeamIdsOfGamelist 배열에 추가 
+                summonerTeamIdsOfGamelist.push(participant.teamId)
+            }
+        })
+    ))
+
+    gameList.map((gameData, index) => (
+        gameData.info.teams.map(team => {
+            // gameData의 팀들 중에서 검색된 소환사의 teamId를 비교 
+            if (team.teamId === summonerTeamIdsOfGamelist[index]) {
+                // 해당 팀의 전체 킬 수를 killsOfGamelist 배열에 추가
+                // 해당 팀의 승리 여부를 summonerTeamIsWin 배열에 추가
+                killsOfGamelist.push(team.objectives.champion.kills)
+                summonerTeamIsWin.push(team.win)
+            }
+        })
+    ))
+    
     return (
         <>
             {searchText === '' ?
@@ -22,8 +50,7 @@ const Match = ({ information, gameList, searchText, leagueList, profileIconID })
                         />
                         {
                             gameList.map((gameData, index) => (
-    
-                                <div key={index} className={styles['gameData-container']}>
+                                <div key={index} className={styles[`gameData-${summonerTeamIsWin[index] ? 'win' : 'lose'}-container`]}>
                                     <h4 className={styles['gameData-gamemode']}>{gameData.info.gameMode}</h4>
     
                                     <div className={styles['gameData-champion']}>
@@ -57,7 +84,17 @@ const Match = ({ information, gameList, searchText, leagueList, profileIconID })
                                     </div>
     
                                     <div className={styles['gameData-individual']}>
-                                        <p>킬관여 : 0%</p>
+                                        {gameData.info.participants.map(participant => {
+                                            // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우
+                                            if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
+                                                return (
+                                                    <div>
+                                                        {/* 소환사의 킬과 어시스트의 합을 소환사가 속한 팀의 전체 킬수로 나누고, 비율을 구함 */}
+                                                        <p>킬관여 : {((participant.kills + participant.assists) / killsOfGamelist[index] * 100).toFixed(0)}%</p>
+                                                    </div>
+                                                )
+                                            }
+                                        })}
                                     </div>
     
                                     <div className={styles['gameData-team']}>

--- a/src/components/contents/Match.js
+++ b/src/components/contents/Match.js
@@ -32,7 +32,7 @@ const Match = ({ information, gameList, searchText, leagueList, profileIconID })
             }
         })
     ))
-    
+
     return (
         <>
             {searchText === '' ?
@@ -50,6 +50,7 @@ const Match = ({ information, gameList, searchText, leagueList, profileIconID })
                         />
                         {
                             gameList.map((gameData, index) => (
+                                // summonerTeamIsWin 배열의 해당 매치 기록의 승패를 확인하여 className을 변경
                                 <div key={index} className={styles[`gameData-${summonerTeamIsWin[index] ? 'win' : 'lose'}-container`]}>
                                     <h4 className={styles['gameData-gamemode']}>{gameData.info.gameMode}</h4>
     

--- a/src/components/contents/Match.module.css
+++ b/src/components/contents/Match.module.css
@@ -2,18 +2,32 @@
     text-align: center;
 }
 
-.gameData-container {
+/* .gameData-container 항목에서 .gameData-win-container로 이름 변경 및
+.gameData-lose-container 항목 추가(겹치는 부분이 많아 하나로 합침) */
+.gameData-win-container,
+.gameData-lose-container {
     margin: auto;
     width: 90%;
     height: 200px;
-    background: linear-gradient(to bottom, #edf1f1, #f1f5f5);
+    /* background 속성 삭제 */
     border: 3px solid rgb(149, 153, 153);
+    /* border 속성이 중복되므로 삭제
     border-bottom: 6px solid rgb(149, 153, 153);
     border-right: 4px solid rgb(149, 153, 153);
-    border-left: 4px solid rgb(149, 153, 153);
+    border-left: 4px solid rgb(149, 153, 153); */
     border-radius: 10px;
     display: flex;
     margin-bottom: 5vh;
+}
+
+/* .gameData-win-container 항목과 .gameData-lose-container 항목의 
+background 속성 부분만 따로 변경 */
+.gameData-win-container {
+    background: greenyellow;
+}
+
+.gameData-lose-container {
+    background: red;
 }
 
 .gameData-gamemode {

--- a/src/components/contents/Match.module.css
+++ b/src/components/contents/Match.module.css
@@ -10,6 +10,7 @@
     width: 90%;
     height: 200px;
     /* background 속성 삭제 */
+    background: greenyellow;
     border: 3px solid rgb(149, 153, 153);
     /* border 속성이 중복되므로 삭제
     border-bottom: 6px solid rgb(149, 153, 153);
@@ -20,12 +21,8 @@
     margin-bottom: 5vh;
 }
 
-/* .gameData-win-container 항목과 .gameData-lose-container 항목의 
+/* .gameData-lose-container 항목의 
 background 속성 부분만 따로 변경 */
-.gameData-win-container {
-    background: greenyellow;
-}
-
 .gameData-lose-container {
     background: red;
 }


### PR DESCRIPTION
1. 매치 기록의 킬관여 구현.

- match.js에서 소환사가 속한 팀의 teamId들을 저장할 summonerTeamIdsOfGamelist 배열 생성, 소환사가 속한 팀의 전체 킬 수들을 저장할 killsOfGamelist 배열 생성, 소환사가 속한 팀의 승리 여부들을 저장할 summonerTeamIsWin 배열 생성.
- gameList를 map을 활용하여 gameData.info.participants에 접근, 다시 map을 활용하여 검색된 소환사의 아이디와 같은 participant에 접근하여 summonerTeamIdsOfGamelist 배열에 소환사가 속한 팀의 teamId를 추가.
- gameList를 map을 활용하여 gameData.info.teams에 접근, 다시 map을 활용하여 검색된 소환사의 teamId가 저장된 summonerTeamIdsOfGamelist 배열의 원소(index로 접근)와 같은 teamId를 가진 team의 전체 킬 수를 killsOfGamelist 배열에 추가 및 해당 팀의 승리 여부를 summonerTeamIsWin 배열에 추가.
- className이 gameData-individual인 div에서 위와 동일한 방법으로 map을 활용하여 participant에 접근하여 participant.kills, participant.assists, killsOfGamelist[index]를 통하여 킬관여를 구현(toFixed(0)을 활용하여 소수점 없이 구현).

2. 매치 기록의 승패에 따른 배경색 구현.

- match.js에서 위에서 언급된 summonerTeamIsWin 배열을 활용.
- className이 gameData-container인 div의 className에 조건문(삼항연산자)을 추가, summonerTeamIsWin 배열의 원소(index로 접근)가 true이면 gameData-win-container, flase면 gameData-lose-container로 변경되게 수정.
- match.module.css에서 .gameData-container 항목의 이름을 gameData-win-container으로 변경 및 동일한 속성을 가진 gameData-lose-container 항목 추가.
- gameData-win-container 항목에서 중복되는 border 속성 삭제.
- gameData-lose-container 항목에서 겹치지 않는 background 속성 수정.

![image](https://user-images.githubusercontent.com/80691239/201047298-c17f15d7-179b-4a4d-bbbc-9526d6a8f780.png)
