### PR TITLE
솔로랭크와 자유랭크 기록이 바뀌는 문제 및 랭크 기록이 없을 시 출력 안되는 문제 해결

### DIFF
--- a/server/proxyServer.js
+++ b/server/proxyServer.js
@@ -8,7 +8,7 @@ const app = express();
 app.use(cors());
 
 // API key
-const API_KEY = "RGAPI-33297b64-e1cf-44e6-86c3-f226c03a8519";
+const API_KEY = "RGAPI-cfb83a07-dbe0-44cd-ace1-d4a8df3a4edc";
 
 // 챔피언 정보를 가져오는 함수
 // const getChampionInfomation = ()

--- a/src/components/contents/SummonerProfile.js
+++ b/src/components/contents/SummonerProfile.js
@@ -32,33 +32,52 @@ const SummonerProfile = ({ information, gameList, searchText, leagueList }) => {
                     </div>
 
                 </div>
-                <div className={styles['summonerProfile-lankInfo']}>                     
-                    <ul className={styles['summonerProfile-soloLank']}>
-                        {emblemImgs.map((list, index) => {
-                            if(list.key == leagueList[0][0]?.tier) {
-                                return (
-                                    <li key={index}><img src={list.Emblem} className={styles['emblemImg']}/></li>
-                                )
-                            }
-                        })}
-                        <li>리그 : 솔로랭크 5X5</li>
-                        <li>티어 : {leagueList[0][0]?.tier} {leagueList[0][0]?.rank}</li>
-                        <li>리그 포인트 : {leagueList[0][0]?.leaguePoints}</li>
-                        <li>{leagueList[0][0]?.wins + leagueList[0][0]?.losses}전 {leagueList[0][0]?.wins}승 {leagueList[0][0]?.losses}패</li>
-                    </ul>
-                    <ul className={styles['summonerProfile-freeLank']}>
-                        {emblemImgs.map((list, index) => {
-                            if(list.key == leagueList[0][1]?.tier) {
-                                return (
-                                    <li key={index}><img src={list.Emblem} className={styles['emblemImg']}/></li>
-                                )
-                            }
-                        })}
-                        <li>리그 : 자유랭크 5X5</li>
-                        <li>티어 : {leagueList[0][1]?.tier} {leagueList[0][1]?.rank}</li>
-                        <li>리그 포인트 : {leagueList[0][1]?.leaguePoints}</li>
-                        <li>{leagueList[0][1]?.wins + leagueList[0][1]?.losses}전 {leagueList[0][1]?.wins}승 {leagueList[0][1]?.losses}패</li>
-                    </ul>
+                {/* 솔로랭크와 자유랭크의 순서를 솔로랭크가 먼저오게 하려고 map을 따로 구현 */}
+                <div className={styles['summonerProfile-rankInfo']}>
+                    {/* leagueList[0] 배열에서 원소가 없으면 No Ranked가 나오게 구현 */}
+                    {leagueList[0].length === 0 ? <p className={styles['summonerProfile-noRanked']}>No Ranked</p> : <p></p>}
+                    {/* leagueList[0] 배열의 list 원소들 중에서 솔로랭크와 자유랭크를 구별하기 위해 map을 통해 접근, queueType으로 구별 */}
+                    {leagueList[0].map((list) => {
+                        if(list.queueType === "RANKED_SOLO_5x5") {
+                            return (
+                                <ul className={styles['summonerProfile-soloRank']}>
+                                    {/* 기존의 emblemImgs의 list는 leagueList[0]의 list와 겹치므로 imgList로 변경, 구별된 list로부터 티어 및 리그포인트에 접근하도록 수정 */}
+                                    {emblemImgs.map((imgList, index) => {
+                                        if(imgList.key == list.tier) {
+                                            return (
+                                                <li key={index}><img src={imgList.Emblem} className={styles['emblemImg']}/></li>
+                                            )
+                                        }
+                                    })}
+                                    <li>리그 : 솔로랭크 5X5</li>
+                                    <li>티어 : {list.tier} {list.rank}</li>
+                                    <li>리그 포인트 : {list.leaguePoints}</li>
+                                    <li>{list.wins + list.losses}전 {list.wins}승 {list.losses}패</li>
+                                </ul>
+                            )
+                        }
+                    })}
+                    {leagueList[0].map((list) => {
+                        {/* leagueList[0] 배열의 list 원소들 중에서 솔로랭크와 자유랭크를 구별하기 위해 map을 통해 접근, queueType으로 구별 */}
+                        if(list.queueType === "RANKED_FLEX_SR") {
+                            return (
+                                <ul className={styles['summonerProfile-freeRank']}>
+                                    {/* 기존의 emblemImgs의 list는 leagueList[0]의 list와 겹치므로 imgList로 변경, 구별된 list로부터 티어 및 리그포인트에 접근하도록 수정 */}
+                                    {emblemImgs.map((imgList, index) => {
+                                        if(imgList.key == list.tier) {
+                                            return (
+                                                <li key={index}><img src={imgList.Emblem} className={styles['emblemImg']}/></li>
+                                            )
+                                        }
+                                    })}
+                                    <li>리그 : 자유랭크 5X5</li>
+                                    <li>티어 : {list.tier} {list.rank}</li>
+                                    <li>리그 포인트 : {list.leaguePoints}</li>
+                                    <li>{list.wins + list.losses}전 {list.wins}승 {list.losses}패</li>
+                                </ul>
+                            )
+                        }
+                    })}
                 </div>
             </div>
         </>

--- a/src/components/contents/SummonerProfile.js
+++ b/src/components/contents/SummonerProfile.js
@@ -27,7 +27,7 @@ const SummonerProfile = ({ information, gameList, searchText, leagueList }) => {
                         id={styles["summonerProfileIcon"]}
                     />
                     <div className={styles['summonerProfile-profile-userInfo']}>
-                        <h3 id={styles["summonerName"]}>{leagueList[0][0]?.summonerName}</h3>
+                        <h3 id={styles["summonerName"]}>{information.name}</h3>
                         <h4 id={styles["summonerLevel"]}>level {information.summonerLevel}</h4>
                     </div>
 

--- a/src/components/contents/SummonerProfile.module.css
+++ b/src/components/contents/SummonerProfile.module.css
@@ -41,7 +41,7 @@
     font-size: 20px;
 }
 
-.summonerProfile-lankInfo {
+.summonerProfile-rankInfo {
     display: flex;
     width: 60%;
     height: 80%;
@@ -55,7 +55,13 @@
     align-items: flex-end;
 }
 
-.summonerProfile-soloLank {
+/* No Ranked의 크기 및 위치를 조정하기 위한 .summonerProfile-noRanked 항목 추가 */
+.summonerProfile-noRanked {
+    font-size: 50px;
+    padding-bottom: 25px;
+}
+
+.summonerProfile-soloRank {
     border: 1px dotted rgb(165, 165, 165);
     width: 50%;
     font-size: 15px;
@@ -64,11 +70,11 @@
     padding: 3px;
 }
 
-.summonerProfile-soloLank li {
+.summonerProfile-soloRank li {
     text-align: center;
 }
 
-.summonerProfile-freeLank {
+.summonerProfile-freeRank {
     border: 1px dotted rgb(165, 165, 165);
     width: 50%;
     font-size: 15px;
@@ -77,7 +83,7 @@
     padding: 3px;
 }
 
-.summonerProfile-freeLank li {
+.summonerProfile-freeRank li {
     text-align: center;
 }
 


### PR DESCRIPTION
1. 솔로랭크와 자유랭크 기록이 바뀌는 문제

- 기존의 코드에서 leagueList[0].map을 활용하여 list.queueType을 통해 솔로랭크와 자유랭크를 구별하게 수정.
- emblemImgs.map에서 사용한 list는 leagueList[0].map의 list와 겹치므로 imgList로 수정.
- 솔로랭크와 자유랭크의 순서를 위해서 map을 따로 두 번 구현.

![image](https://user-images.githubusercontent.com/80691239/201287292-7412b8da-bf0d-4df3-b962-3cda353d6ed9.png)

2. 랭크 기록이 없을 시 출력이 안되는 문제

- 기존의 코드는 배열에 없어도 접근이 되도록 되어 있어서 출력이 잘 안되었음.
- 위에서 설명한 leagueList[0].map을 사용하여 없으면 아예 출력이 안되게 변경.
- 솔로랭크와 자유랭크 모두 없을 경우 No Ranked로 나오게 삼항연산자를 사용.
- No Ranked의 크기와 위치를 변경하기 위해 SummonerProfile.module.css 에서 항목 추가 및 속성 추가.

![image](https://user-images.githubusercontent.com/80691239/201287354-3c362063-b70e-4b1b-9ab6-1cd62d7cd13b.png)
![image](https://user-images.githubusercontent.com/80691239/201287685-bef57fe2-9652-4303-a709-c1b7de8739ce.png)
