### PR TITLE
랭크기록이 없을 경우 표시문구 변경 및 매치기록 승/패 색상 변경

### DIFF
--- a/server/proxyServer.js
+++ b/server/proxyServer.js
@@ -8,7 +8,7 @@ const app = express();
 app.use(cors());
 
 // API key
-const API_KEY = "RGAPI-33297b64-e1cf-44e6-86c3-f226c03a8519";
+const API_KEY = "RGAPI-cfb83a07-dbe0-44cd-ace1-d4a8df3a4edc";
 
 // 챔피언 정보를 가져오는 함수
 // const getChampionInfomation = ()

--- a/src/components/contents/Match.js
+++ b/src/components/contents/Match.js
@@ -85,11 +85,11 @@ const Match = ({ information, gameList, searchText, leagueList, profileIconID })
                                     </div>
     
                                     <div className={styles['gameData-individual']}>
-                                        {gameData.info.participants.map(participant => {
+                                        {gameData.info.participants.map((participant, index) => {
                                             // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우
                                             if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
                                                 return (
-                                                    <div>
+                                                    <div key={index}>
                                                         {/* 소환사의 킬과 어시스트의 합을 소환사가 속한 팀의 전체 킬수로 나누고, 비율을 구함 */}
                                                         <p>킬관여 : {((participant.kills + participant.assists) / killsOfGamelist[index] * 100).toFixed(0)}%</p>
                                                     </div>

--- a/src/components/contents/Match.module.css
+++ b/src/components/contents/Match.module.css
@@ -10,7 +10,7 @@
     width: 90%;
     height: 200px;
     /* background 속성 삭제 */
-    background: greenyellow;
+    background: rgb(170, 248, 155);
     border: 3px solid rgb(149, 153, 153);
     /* border 속성이 중복되므로 삭제
     border-bottom: 6px solid rgb(149, 153, 153);
@@ -24,7 +24,7 @@
 /* .gameData-lose-container 항목의 
 background 속성 부분만 따로 변경 */
 .gameData-lose-container {
-    background: red;
+    background: rgb(255, 166, 166);
 }
 
 .gameData-gamemode {

--- a/src/components/contents/Match.module.css
+++ b/src/components/contents/Match.module.css
@@ -2,29 +2,20 @@
     text-align: center;
 }
 
-/* .gameData-container 항목에서 .gameData-win-container로 이름 변경 및
-.gameData-lose-container 항목 추가(겹치는 부분이 많아 하나로 합침) */
 .gameData-win-container,
 .gameData-lose-container {
     margin: auto;
     width: 90%;
     height: 200px;
-    /* background 속성 삭제 */
-    background: greenyellow;
+    background: rgb(158, 247, 123);
     border: 3px solid rgb(149, 153, 153);
-    /* border 속성이 중복되므로 삭제
-    border-bottom: 6px solid rgb(149, 153, 153);
-    border-right: 4px solid rgb(149, 153, 153);
-    border-left: 4px solid rgb(149, 153, 153); */
     border-radius: 10px;
     display: flex;
     margin-bottom: 5vh;
 }
 
-/* .gameData-lose-container 항목의 
-background 속성 부분만 따로 변경 */
 .gameData-lose-container {
-    background: red;
+    background: rgb(245, 121, 121);
 }
 
 .gameData-gamemode {

--- a/src/components/contents/SummonerProfile.js
+++ b/src/components/contents/SummonerProfile.js
@@ -35,7 +35,7 @@ const SummonerProfile = ({ information, gameList, searchText, leagueList }) => {
                 {/* 솔로랭크와 자유랭크의 순서를 솔로랭크가 먼저오게 하려고 map을 따로 구현 */}
                 <div className={styles['summonerProfile-rankInfo']}>
                     {/* leagueList[0] 배열에서 원소가 없으면 No Ranked가 나오게 구현 */}
-                    {leagueList[0].length === 0 ? <p className={styles['summonerProfile-noRanked']}>No Ranked</p> : <p></p>}
+                    {leagueList[0].length === 0 ? <p className={styles['summonerProfile-unRanked']}>Unranked</p> : <p></p>}
                     {/* leagueList[0] 배열의 list 원소들 중에서 솔로랭크와 자유랭크를 구별하기 위해 map을 통해 접근, queueType으로 구별 */}
                     {leagueList[0].map((list) => {
                         if(list.queueType === "RANKED_SOLO_5x5") {

--- a/src/components/contents/SummonerProfile.module.css
+++ b/src/components/contents/SummonerProfile.module.css
@@ -44,7 +44,7 @@
 .summonerProfile-rankInfo {
     display: flex;
     width: 60%;
-    height: 80%;
+    height: 240px;
     float: right;
     border: 1px solid black;
     margin-top: 20px;
@@ -55,10 +55,11 @@
     align-items: flex-end;
 }
 
-/* No Ranked의 크기 및 위치를 조정하기 위한 .summonerProfile-noRanked 항목 추가 */
-.summonerProfile-noRanked {
-    font-size: 50px;
-    padding-bottom: 25px;
+.summonerProfile-unRanked {
+    font-size: 40px;
+    font-weight: bold;
+    color: rgb(100, 97, 97);
+    padding-bottom: 50px;
 }
 
 .summonerProfile-soloRank {


### PR DESCRIPTION
랭크기록이 없을 경우 표시문구를 변경하고 매치기록 승/패 색상을 변경함.

![image](https://user-images.githubusercontent.com/17917009/201297697-22aba519-57f4-479a-a18e-d447aacd1f38.png)

- 'No ranked' 에서 'Unranked'로 변경

![image](https://user-images.githubusercontent.com/17917009/201297517-502bc4cd-9c6a-4387-851e-083abfa305f6.png)

- 다음과 같이 색상을 변경함.
- 승리시 색상  :  rgb(82, 255, 47); => rgb(170, 248, 155);
- 패배시 색상  :  rgb(255, 0, 0) => rgb(255, 166, 166)

