### PR TITLE
킬관여 및 평점이 제대로 나오지 않는 현상 해결

### DIFF
--- a/server/proxyServer.js
+++ b/server/proxyServer.js
@@ -8,7 +8,7 @@ const app = express();
 app.use(cors());
 
 // API key
-const API_KEY = "RGAPI-cfb83a07-dbe0-44cd-ace1-d4a8df3a4edc";
+const API_KEY = "RGAPI-ec1e1276-ca87-4d4a-aad3-689edbdb73a0";
 
 // 챔피언 정보를 가져오는 함수
 // const getChampionInfomation = ()

--- a/src/components/contents/Match.js
+++ b/src/components/contents/Match.js
@@ -77,7 +77,8 @@ const Match = ({ information, gameList, searchText, leagueList, profileIconID })
                                                         {/* KDA */}
                                                         <h3>{participant.kills}/{participant.deaths}/{participant.assists}</h3>
                                                         {/* 평점 */}
-                                                        <p>{((participant.kills + participant.assists)/participant.deaths).toFixed(2)} 평점</p>
+                                                        {/* participant.deaths가 0인 경우 평점이 제대로 나오지 않는 현상 발생, 삼항연산자로 0인 경우를 따로 지정*/}
+                                                        <p>{((participant.kills + participant.assists)/(participant.deaths === 0 ? 1 : participant.deaths)).toFixed(2)} 평점</p>
                                                     </div>
                                                 )
                                             }
@@ -85,7 +86,8 @@ const Match = ({ information, gameList, searchText, leagueList, profileIconID })
                                     </div>
     
                                     <div className={styles['gameData-individual']}>
-                                        {gameData.info.participants.map((participant, index) => {
+                                        {/* 킬관여가 NaN으로 표기되는 현상 발생, map의 인자에 participant, index로 되어있는 것을 index를 제거, gameList의 index를 사용하도록 수정 */}
+                                        {gameData.info.participants.map((participant) => {
                                             // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우
                                             if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
                                                 return (

--- a/src/components/contents/Match.js
+++ b/src/components/contents/Match.js
@@ -77,8 +77,8 @@ const Match = ({ information, gameList, searchText, leagueList, profileIconID })
                                                         {/* KDA */}
                                                         <h3>{participant.kills}/{participant.deaths}/{participant.assists}</h3>
                                                         {/* 평점 */}
-                                                        {/* participant.deaths가 0인 경우 평점이 제대로 나오지 않는 현상 발생, 삼항연산자로 0인 경우를 따로 지정*/}
-                                                        <p>{((participant.kills + participant.assists)/(participant.deaths === 0 ? 1 : participant.deaths)).toFixed(2)} 평점</p>
+                                                        {/* participant.deaths가 0인 경우 평점이 제대로 나오지 않는 현상 발생, 삼항연산자로 0인 경우에 Perfect가 나오게 수정*/}
+                                                        <p>{((participant.deaths === 0 ? "Perfect" : ((participant.kills + participant.assists) / participant.deaths).toFixed(2)))} 평점</p>
                                                     </div>
                                                 )
                                             }


### PR DESCRIPTION
1. 킬관여가 제대로 나오지 않는 현상

- killsOfGamelist[index]에서 index때문에 제대로 나오지 않는 것을 확인.
- gameData.info.participants.map의 index를 사용하는 것을 상위에 있는 gameList.map의 index를 사용하도록 변경(gameData.info.participants.map의 index 인자를 제거).

![image](https://user-images.githubusercontent.com/80691239/201586321-5013602d-df6b-476a-af26-f646caa6b410.png)


2. 평점이 제대로 나오지 않는 현상

- participant.deaths가 0인 경우 평점이 제대로 나오지 않는 현상 발생.
- 삼항연산자를 사용하여 participant.deaths가 0인 경우 Perfect가 나오게 수정.

![image](https://user-images.githubusercontent.com/80691239/201587566-e792ea31-ea19-4413-a03d-7d846c1f1f4d.png)
