### PR TITLE
매치상세기록창 구현

### DIFF
--- a/server/proxyServer.js
+++ b/server/proxyServer.js
@@ -7,7 +7,7 @@ const app = express();
 app.use(cors());
 
 // API key
-const API_KEY = "RGAPI-2f005a94-91f8-40fc-870e-b8cd0ebdcbe2";
+const API_KEY = "RGAPI-da65cc5d-7397-4272-b3ff-66b844e12f34";
 
 // 아이템 정보를 가져오는 함수
 const getItemInfomation = () => {

--- a/src/components/contents/Match.js
+++ b/src/components/contents/Match.js
@@ -1,17 +1,20 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styles from "./Match.module.css";
 import SummonerProfile from "./SummonerProfile";
 
 // 매치기록 컴포넌트
-const Match = ({ playerInformation, gameList, searchText, leagueList, profileIconID }) => {
+const Match = ({ playerInformation, gameList, searchText, leagueList }) => {
     // 소환사가 속한 팀의 teamId들을 저장할 summonerTeamIdsOfGamelist 배열 생성
     // 소환사가 속한 팀의 전체 킬 수들을 저장할 killsOfGamelist 배열 생성
     // 소환사가 속한 팀의 승리 여부들을 저장할 summonerTeamIsWin 배열 생성
     const summonerTeamIdsOfGamelist = [];
     const killsOfGamelist = [];
     const summonerTeamIsWin = [];
+    const visibleArr = [];
+    const [visible, setVisible] = useState([...visibleArr]);
 
-    gameList.map((gameData) => (
+    gameList.map((gameData, index) => {
+        visibleArr.push(false)
         gameData.info.participants.map(participant => {
             // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우 
             if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
@@ -19,9 +22,6 @@ const Match = ({ playerInformation, gameList, searchText, leagueList, profileIco
                 summonerTeamIdsOfGamelist.push(participant.teamId)
             }
         })
-    ))
-
-    gameList.map((gameData, index) => (
         gameData.info.teams.map(team => {
             // gameData의 팀들 중에서 검색된 소환사의 teamId를 비교 
             if (team.teamId === summonerTeamIdsOfGamelist[index]) {
@@ -31,7 +31,12 @@ const Match = ({ playerInformation, gameList, searchText, leagueList, profileIco
                 summonerTeamIsWin.push(team.win)
             }
         })
-    ))
+    })
+    
+    useEffect(() => {
+        setVisible([...visibleArr])
+        console.log(visible)
+    }, [])
 
     return (
         <>
@@ -46,114 +51,191 @@ const Match = ({ playerInformation, gameList, searchText, leagueList, profileIco
                             gameList={gameList} 
                             searchText={searchText} 
                             leagueList={leagueList} 
-                            profileIconID={profileIconID}
                         />
                         {
                             gameList.map((gameData, index) => (
-                                // summonerTeamIsWin 배열의 해당 매치 기록의 승패를 확인하여 className을 변경
-                                <div key={index} className={styles[`gameData-${summonerTeamIsWin[index] ? 'win' : 'lose'}-container`]}>
-                                    <h4 className={styles['gameData-gamemode']}>{gameData.info.gameMode}</h4>
-    
-                                    <div className={styles['gameData-champion']}>
-                                        {gameData.info.participants.map(participant => {
-                                            // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우 
-                                            if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
-                                                return (
-                                                    <div key={index}>
-                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${participant.championName}.png`}/>
-                                                        <h3>{participant.championName}</h3>
-                                                    </div>
-                                                )
-                                            }
-                                        })}
-                                    </div>
-    
-                                    <div className={styles['gameData-kda']}>
-                                        {gameData.info.participants.map(participant => {
-                                            // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우
-                                            if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
-                                                return (
-                                                    <div key={index}>
-                                                        {/* KDA */}
-                                                        <h3>{participant.kills}/{participant.deaths}/{participant.assists}</h3>
-                                                        {/* 평점 */}
-
-                                                        {/* participant.deaths가 0인 경우 평점이 제대로 나오지 않는 현상 발생, 삼항연산자로 0인 경우에 Perfect가 나오게 수정*/}
-                                                        <p>{((participant.deaths === 0 ? "Perfect" : ((participant.kills + participant.assists) / participant.deaths).toFixed(2)))} 평점</p>
-                                                    </div>
-                                                )
-                                            }
-                                        })}
-                                    </div>
-    
-                                    <div className={styles['gameData-individual']}>
-                                        {/* 킬관여가 NaN으로 표기되는 현상 발생, map의 인자에 participant, index로 되어있는 것을 index를 제거, gameList의 index를 사용하도록 수정 */}
-                                        {gameData.info.participants.map((participant) => {
-                                            // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우
-                                            if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
-                                                return (
-                                                    <div key={index}>
-                                                        {/* 소환사의 킬과 어시스트의 합을 소환사가 속한 팀의 전체 킬수로 나누고, 비율을 구함 */}
-                                                        <p>킬관여 : {((participant.kills + participant.assists) / killsOfGamelist[index] * 100).toFixed(0)}%</p>
-                                                    </div>
-                                                )
-                                            }
-                                        })}
-                                    </div>
-    
-                                    <div className={styles['gameData-team']}>
-                                        <div className={styles['gameData-team1']}>
-                                            <p className={styles['gameData-teamtitle']}>Team 1</p>
-                                            <ul>
-                                                {/* 반복되는 코드가 많아 map을 사용 */}
-                                                {gameData.info.participants.map((participant, index) => {
-                                                    if (index < 5) {
-                                                        return (
-                                                            <li>
-                                                                <img 
-                                                                    src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${gameData.info.participants[index].championName}.png`}
-                                                                    className={styles['gameData-championMiniFaceImg']}
-                                                                />
-                                                                <div className={styles['gameData-usersInfoBox']}>
-                                                                    {/* 유저 닉네임 */}
-                                                                    <div>{gameData.info.participants[index].summonerName}</div>
-                                                                    {/* 각 유저들의 KDA */}
-                                                                    <div>{gameData.info.participants[index].kills}/{gameData.info.participants[index].deaths}/{gameData.info.participants[index].assists} </div>
-                                                                </div>
-                                                            </li>
-                                                        )
-                                                    }
-                                                })}
-                                            </ul>
+                                <div key={index}>
+                                    {/* summonerTeamIsWin 배열의 해당 매치 기록의 승패를 확인하여 className을 변경 */}
+                                    <div className={styles[`gameData-${summonerTeamIsWin[index] ? 'win' : 'lose'}-container`]}>
+                                        <h4 className={styles['gameData-gamemode']}>{gameData.info.gameMode}</h4>
+        
+                                        <div className={styles['gameData-champion']}>
+                                            {gameData.info.participants.map(participant => {
+                                                // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우 
+                                                if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
+                                                    return (
+                                                        <div key={index}>
+                                                            <img src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${participant.championName}.png`}/>
+                                                            <h3>{participant.championName}</h3>
+                                                        </div>
+                                                    )
+                                                }
+                                            })}
                                         </div>
-                                        <div className={styles['gameData-team2']}>
-                                            <p className={styles['gameData-teamtitle']}>Team 2</p>
-                                            <ul>
-                                                {/* 반복되는 코드가 많아 map을 사용 */}
-                                                {gameData.info.participants.map((participant, index) => {
-                                                    if (index >= 5 && index < 10) {
-                                                        return (
-                                                            <li>
-                                                                <img 
-                                                                    src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${gameData.info.participants[index].championName}.png`}
-                                                                    className={styles['gameData-championMiniFaceImg']}
-                                                                />
-                                                                <div className={styles['gameData-usersInfoBox']}>
-                                                                    {/* 유저 닉네임 */}
-                                                                    <div>{gameData.info.participants[index].summonerName}</div>
-                                                                    {/* 각 유저들의 KDA */}
-                                                                    <div>{gameData.info.participants[index].kills}/{gameData.info.participants[index].deaths}/{gameData.info.participants[index].assists} </div>
-                                                                </div>
-                                                            </li>
-                                                        )
-                                                    }
-                                                })}
-                                            </ul>
+        
+                                        <div className={styles['gameData-kda']}>
+                                            {gameData.info.participants.map(participant => {
+                                                // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우
+                                                if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
+                                                    return (
+                                                        <div key={index}>
+                                                            {/* KDA */}
+                                                            <h3>{participant.kills}/{participant.deaths}/{participant.assists}</h3>
+                                                            {/* 평점 */}
+
+                                                            {/* participant.deaths가 0인 경우 평점이 제대로 나오지 않는 현상 발생, 삼항연산자로 0인 경우에 Perfect가 나오게 수정*/}
+                                                            <p>{((participant.deaths === 0 ? "Perfect" : ((participant.kills + participant.assists) / participant.deaths).toFixed(2)))} 평점</p>
+                                                        </div>
+                                                    )
+                                                }
+                                            })}
+                                        </div>
+        
+                                        <div className={styles['gameData-individual']}>
+                                            {/* 킬관여가 NaN으로 표기되는 현상 발생, map의 인자에 participant, index로 되어있는 것을 index를 제거, gameList의 index를 사용하도록 수정 */}
+                                            {gameData.info.participants.map((participant) => {
+                                                // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우
+                                                if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
+                                                    return (
+                                                        <div key={index}>
+                                                            {/* 소환사의 킬과 어시스트의 합을 소환사가 속한 팀의 전체 킬수로 나누고, 비율을 구함 */}
+                                                            <p>킬관여 : {((participant.kills + participant.assists) / killsOfGamelist[index] * 100).toFixed(0)}%</p>
+                                                        </div>
+                                                    )
+                                                }
+                                            })}
+                                        </div>
+        
+                                        <div className={styles['gameData-team']}>
+                                            <div className={styles['gameData-team1']}>
+                                                <p className={styles['gameData-teamtitle']}>Team 1</p>
+                                                <ul>
+                                                    {/* 반복되는 코드가 많아 map을 사용 */}
+                                                    {gameData.info.participants.map((participant, index) => {
+                                                        if (index < 5) {
+                                                            return (
+                                                                <li>
+                                                                    <img 
+                                                                        src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${gameData.info.participants[index].championName}.png`}
+                                                                        className={styles['gameData-championMiniFaceImg']}
+                                                                    />
+                                                                    <div className={styles['gameData-usersInfoBox']}>
+                                                                        {/* 유저 닉네임 */}
+                                                                        <div>{gameData.info.participants[index].summonerName}</div>
+                                                                        {/* 각 유저들의 KDA */}
+                                                                        <div>{gameData.info.participants[index].kills}/{gameData.info.participants[index].deaths}/{gameData.info.participants[index].assists} </div>
+                                                                    </div>
+                                                                </li>
+                                                            )
+                                                        }
+                                                    })}
+                                                </ul>
+                                            </div>
+                                            <div className={styles['gameData-team2']}>
+                                                <p className={styles['gameData-teamtitle']}>Team 2</p>
+                                                <ul>
+                                                    {/* 반복되는 코드가 많아 map을 사용 */}
+                                                    {gameData.info.participants.map((participant, index) => {
+                                                        if (index >= 5 && index < 10) {
+                                                            return (
+                                                                <li>
+                                                                    <img 
+                                                                        src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${gameData.info.participants[index].championName}.png`}
+                                                                        className={styles['gameData-championMiniFaceImg']}
+                                                                    />
+                                                                    <div className={styles['gameData-usersInfoBox']}>
+                                                                        {/* 유저 닉네임 */}
+                                                                        <div>{gameData.info.participants[index].summonerName}</div>
+                                                                        {/* 각 유저들의 KDA */}
+                                                                        <div>{gameData.info.participants[index].kills}/{gameData.info.participants[index].deaths}/{gameData.info.participants[index].assists} </div>
+                                                                    </div>
+                                                                </li>
+                                                            )
+                                                        }
+                                                    })}
+                                                </ul>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <button onClick={() => {
+                                                visibleArr[index] = !visibleArr[index];
+                                                setVisible([...visibleArr])
+                                                console.log(visibleArr, "visibleArr")
+                                                console.log(visible, "visible")
+                                            }}>
+                                                누르기
+                                            </button>
+                                            
                                         </div>
                                     </div>
-
+                                    {visible[index] !== true ? 
+                                        <div></div> : 
+                                            <div>
+                                                <div className={styles[`gameData-detail-win-container`]}>
+                                                    {gameData.info.participants.map((participant, index) => {
+                                                        console.log(gameData.info.participants)
+                                                        if (participant.win === true) {
+                                                            return (
+                                                                <div className={styles[`detail-list`]}>
+                                                                    <div className={styles[`participant-img`]}>
+                                                                        <img 
+                                                                            src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${gameData.info.participants[index].championName}.png`}
+                                                                            className={styles['gameData-championMiniFaceImg']}
+                                                                        />
+                                                                    </div>
+                                                                    
+                                                                    <div className={styles[`participant-name`]}>{gameData.info.participants[index].summonerName}</div>
+                                                                    <div className={styles[`participant-kda`]}>{gameData.info.participants[index].kills}/{gameData.info.participants[index].deaths}/{gameData.info.participants[index].assists}</div>
+                                                                    <div className={styles[`participant-total-damage-champions`]}>챔피언 딜량 : {gameData.info.participants[index].totalDamageDealtToChampions}</div>
+                                                                    <div className={styles[`participant-total-minions-killed`]}>cs : {gameData.info.participants[index].totalMinionsKilled + gameData.info.participants[index].neutralMinionsKilled}</div>
+                                                                    <div className={styles[`participant-total-wards-placed`]}>와드 설치 : {gameData.info.participants[index].wardsPlaced}</div>
+                                                                    <div className={styles[`participant-item`]}>
+                                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${gameData.info.participants[index].item0}.png`} oneerror="aa" />
+                                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${gameData.info.participants[index].item1}.png`} />
+                                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${gameData.info.participants[index].item2}.png`} />
+                                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${gameData.info.participants[index].item3}.png`} />
+                                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${gameData.info.participants[index].item4}.png`} />
+                                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${gameData.info.participants[index].item5}.png`} />
+                                                                    </div>
+                                                                </div>
+                                                            )
+                                                        }
+                                                    })}
+                                                </div>
+                                                <div className={styles[`gameData-detail-lose-container`]}>
+                                                    {gameData.info.participants.map((participant, index) => {
+                                                        if (participant.win === false) {
+                                                            return (
+                                                                <div className={styles[`detail-list`]}>
+                                                                    <div className={styles[`participant-img`]}>
+                                                                        <img 
+                                                                            src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${gameData.info.participants[index].championName}.png`}
+                                                                            className={styles['gameData-championMiniFaceImg']}
+                                                                        />
+                                                                    </div>
+                                                                    
+                                                                    <div className={styles[`participant-name`]}>{gameData.info.participants[index].summonerName}</div>
+                                                                    <div className={styles[`participant-kda`]}>{gameData.info.participants[index].kills}/{gameData.info.participants[index].deaths}/{gameData.info.participants[index].assists}</div>
+                                                                    <div className={styles[`participant-total-damage-champions`]}>챔피언 딜량 : {gameData.info.participants[index].totalDamageDealtToChampions}</div>
+                                                                    <div className={styles[`participant-total-minions-killed`]}>cs : {gameData.info.participants[index].totalMinionsKilled + gameData.info.participants[index].neutralMinionsKilled}</div>
+                                                                    <div className={styles[`participant-total-wards-placed`]}>와드 설치 : {gameData.info.participants[index].wardsPlaced}</div>
+                                                                    <div className={styles[`participant-item`]}>
+                                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${gameData.info.participants[index].item0}.png`} />
+                                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${gameData.info.participants[index].item1}.png`} />
+                                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${gameData.info.participants[index].item2}.png`} />
+                                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${gameData.info.participants[index].item3}.png`} />
+                                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${gameData.info.participants[index].item4}.png`} />
+                                                                        <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${gameData.info.participants[index].item5}.png`} />
+                                                                    </div>
+                                                                </div>
+                                                            )
+                                                        }
+                                                    })}
+                                                </div>
+                                                
+                                            </div>
+                                    }
                                 </div>
-                                
                             ))
                         }
                     </> : null

--- a/src/components/contents/Match.module.css
+++ b/src/components/contents/Match.module.css
@@ -11,7 +11,8 @@
     border: 3px solid rgb(149, 153, 153);
     border-radius: 10px;
     display: flex;
-    margin-bottom: 5vh;
+    margin-top: 2.5vh;
+    margin-bottom: 2.5vh;
 }
 
 .gameData-lose-container {
@@ -85,9 +86,64 @@
     margin-right: 5px;
 }
 
-
 .gameData-usersInfoBox {
     width: 100%;
     display: flex;
     justify-content: space-between;
+}
+
+.gameData-detail-win-container,
+.gameData-detail-lose-container {
+    margin: auto;
+    width: 90%;
+    height: 200px;
+    background: rgb(170, 248, 155);
+    border: 3px solid rgb(149, 153, 153);
+}
+
+.gameData-detail-lose-container {
+    background: rgb(255, 166, 166);
+}
+
+.detail-list {
+    height: 37px;
+    padding-left: 10px;
+    display: flex;
+    align-items: center;
+    border: 2px solid rgb(149, 153, 153);
+}
+
+.participant-img {
+    display: flex;
+    margin-right: 10px;
+    width: 50px;
+    height: 25px;
+}
+
+.participant-name {
+    width: 150px;
+}
+
+.participant-kda,
+.participant-total-wards-placed,
+.participant-total-minions-killed {
+    width: 150px;
+    text-align: center;
+}
+
+.participant-total-damage-champions {
+    width: 200px;
+    text-align: center;
+}
+
+.participant-item {
+    display: flex;
+    justify-content: center;
+    width: 350px;
+    height: 25px;
+}
+
+.participant-item img {
+    width: 25px;
+    height: 25px;
 }


### PR DESCRIPTION
1. 매치상세기록창 구현

- match.js에서 매치상세기록창을 보여주는 버튼 구현(css 미구현)
- useState를 사용, 버튼 클릭시 useState가 변경되도록 구현
- useState의 변수에 따라 true인 경우에 매치상세기록창이 보이게 구현
- 승리한 팀, 패배한 팀을 구분하여 챔피언 이미지, 소환사 이름, kda, 딜량, cs, 와드 설치, 아이템을 보여주도록 구현

![image](https://user-images.githubusercontent.com/80691239/202656275-79cd2aa7-eff8-4dbd-ab00-1f1c7c033310.png)
