### PR TITLE
검색텍스트를 지울 때 이전 검색 결과가 변경되는 현상 수정 및 아이템 정보 탭 및 페이지 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Home from './pages/Home';
 import ChampionInfo from './pages/ChampionInfo';
 import ChampionDetailInfo from './pages/ChampionDetailInfo.js';
 import NoImage from "./Data/Etc/NoImage.jpg";
+import ItemInfo from './pages/ItemInfo.js';
 
 // App
 function App() {
@@ -102,6 +103,16 @@ function App() {
                         <ChampionDetailInfo
                             championData={championData}
                             item={item}
+                            onErrorImg={onErrorImg}
+                        />
+                    }
+                ></Route>
+
+                {/* Route => /item */}
+                <Route
+                    path='/item'
+                    element={
+                        <ItemInfo 
                             onErrorImg={onErrorImg}
                         />
                     }

--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -7,7 +7,8 @@ const Header = () => {
     return <>
         <nav className={styles['Header-container']}>
             <Link to="/" className={styles["Header-tab"]}>전적검색</Link>
-            <Link to="/championInfo" className={styles["Header-tab"]}>챔피언정보</Link>
+            <Link to="/championInfo" className={styles["Header-tab"]}>챔피언</Link>
+            <Link to="/item" className={styles["Header-tab"]}>아이템</Link>
         </nav>
     </>
 }

--- a/src/components/contents/Match.js
+++ b/src/components/contents/Match.js
@@ -65,7 +65,11 @@ const Match = ({ playerInformation, gameList, searchText, leagueList, onErrorImg
                                                 if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
                                                     return (
                                                         <div key={index}>
-                                                            <img src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${participant.championName}.png`} onError={onErrorImg} />
+                                                            <img 
+                                                                src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${participant.championName}.png`} 
+                                                                onError={onErrorImg} 
+                                                                alt={participant.championName}
+                                                            />
                                                             <h3>{participant.championName}</h3>
                                                         </div>
                                                     )
@@ -119,6 +123,7 @@ const Match = ({ playerInformation, gameList, searchText, leagueList, onErrorImg
                                                                         src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${gameData.info.participants[index].championName}.png`}
                                                                         className={styles['gameData-championMiniFaceImg']}
                                                                         onError={onErrorImg}
+                                                                        alt={participant.championName}
                                                                     />
                                                                     <div className={styles['gameData-usersInfoBox']}>
                                                                         {/* 유저 닉네임 */}
@@ -144,6 +149,7 @@ const Match = ({ playerInformation, gameList, searchText, leagueList, onErrorImg
                                                                         src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${gameData.info.participants[index].championName}.png`}
                                                                         className={styles['gameData-championMiniFaceImg']}
                                                                         onError={onErrorImg}
+                                                                        alt={participant.championName}
                                                                     />
                                                                     <div className={styles['gameData-usersInfoBox']}>
                                                                         {/* 유저 닉네임 */}

--- a/src/components/contents/Match.js
+++ b/src/components/contents/Match.js
@@ -5,7 +5,13 @@ import SummonerProfile from "./SummonerProfile";
 import { FaArrowDown } from "react-icons/fa";
 
 // 매치기록 컴포넌트
-const Match = ({ playerInformation, gameList, searchText, leagueList, onErrorImg }) => {
+const Match = ({ 
+    playerInformation, 
+    gameList, 
+    leagueList, 
+    onErrorImg,
+    nickname,
+}) => {
     const summonerTeamIdsOfGamelist = []; // 소환사가 속한 팀의 teamId들을 저장할 summonerTeamIdsOfGamelist 배열 생성
     const killsOfGamelist = []; // 소환사가 속한 팀의 전체 킬 수들을 저장할 killsOfGamelist 배열 생성
     const summonerTeamIsWin = []; // 소환사가 속한 팀의 승리 여부들을 저장할 summonerTeamIsWin 배열 생성
@@ -17,7 +23,7 @@ const Match = ({ playerInformation, gameList, searchText, leagueList, onErrorImg
         visibleArr.push(false)
         gameData.info.participants.map(participant => {
             // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우 
-            if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
+            if (participant.summonerName.toUpperCase() === (decodeURIComponent(nickname)).toUpperCase()) {
                 // 검색된 소환사의 teamId를 summonerTeamIdsOfGamelist 배열에 추가 
                 summonerTeamIdsOfGamelist.push(participant.teamId)
             }
@@ -32,15 +38,16 @@ const Match = ({ playerInformation, gameList, searchText, leagueList, onErrorImg
             }
         })
     })
-    
+
     // visible : [false, false, false, false, false, false, false, false, false, false]
     useEffect(() => {
         setVisible([...visibleArr])
     }, [])
+    
 
     return (
         <>
-            {searchText === '' ?
+            {nickname === '' ?
                 <div></div> : 
                 (
                     gameList.length !== 0 ? 
@@ -48,8 +55,6 @@ const Match = ({ playerInformation, gameList, searchText, leagueList, onErrorImg
                         <h3 className={styles["gameData-title"]}>검색결과</h3>
                         <SummonerProfile 
                             playerInformation={playerInformation}
-                            gameList={gameList} 
-                            searchText={searchText} 
                             leagueList={leagueList} 
                         />
                         {
@@ -61,8 +66,8 @@ const Match = ({ playerInformation, gameList, searchText, leagueList, onErrorImg
         
                                         <div className={styles['gameData-champion']}>
                                             {gameData.info.participants.map(participant => {
-                                                // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우 
-                                                if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
+                                                // gameData안의 각 participant의 summonrName과 디코딩된 nickname값이 대소문자구분없이 같을 경우 
+                                                if (participant.summonerName.toUpperCase() === (decodeURIComponent(nickname)).toUpperCase()) {
                                                     return (
                                                         <div key={index}>
                                                             <img 
@@ -79,8 +84,8 @@ const Match = ({ playerInformation, gameList, searchText, leagueList, onErrorImg
         
                                         <div className={styles['gameData-kda']}>
                                             {gameData.info.participants.map(participant => {
-                                                // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우
-                                                if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
+                                                // gameData안의 각 participant의 summonrName과 디코딩된 nickname값이 대소문자구분없이 같을 경우
+                                                if (participant.summonerName.toUpperCase() === (decodeURIComponent(nickname)).toUpperCase()) {
                                                     return (
                                                         <div key={index}>
                                                             {/* KDA */}
@@ -98,8 +103,8 @@ const Match = ({ playerInformation, gameList, searchText, leagueList, onErrorImg
                                         <div className={styles['gameData-individual']}>
                                             {/* 킬관여가 NaN으로 표기되는 현상 발생, map의 인자에 participant, index로 되어있는 것을 index를 제거, gameList의 index를 사용하도록 수정 */}
                                             {gameData.info.participants.map((participant) => {
-                                                // gameData안의 각 participant의 summonrName과 디코딩된 searchText값이 대소문자구분없이 같을 경우
-                                                if (participant.summonerName.toUpperCase() === (decodeURIComponent(searchText)).toUpperCase()) {
+                                                // gameData안의 각 participant의 summonrName과 디코딩된 nickname값이 대소문자구분없이 같을 경우
+                                                if (participant.summonerName.toUpperCase() === (decodeURIComponent(nickname)).toUpperCase()) {
                                                     return (
                                                         <div key={index}>
                                                             {/* 소환사의 킬과 어시스트의 합을 소환사가 속한 팀의 전체 킬수로 나누고, 비율을 구함 */}

--- a/src/components/contents/MatchDetail.js
+++ b/src/components/contents/MatchDetail.js
@@ -10,7 +10,7 @@ const MatchDetail = ({ gameData, onErrorImg }) => {
                 // 승리한 팀
                 if (participant.win === true) {
                     return  (
-                        <div className={styles[`gameData-detail-win-container`]}>
+                        <div className={styles[`gameData-detail-win-container`]} key={index}>
                             <div className={styles[`detail-list`]}>
                                 {/* 소환사가 플레이한 챔피언의 이미지 */}
                                 <div className={styles[`participant-img`]}>
@@ -18,6 +18,7 @@ const MatchDetail = ({ gameData, onErrorImg }) => {
                                         src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${participant.championName}.png`}
                                         className={styles['gameData-championMiniFaceImg']}
                                         onError={onErrorImg}
+                                        alt={participant.championName}
                                     />
                                 </div>
                                 {/* 소환사명 */}
@@ -32,12 +33,12 @@ const MatchDetail = ({ gameData, onErrorImg }) => {
                                 <div className={styles[`participant-total-wards-placed`]}>와드 설치 : {participant.wardsPlaced}</div>
                                 {/* 아이템이미지 */}
                                 <div className={styles[`participant-item`]}> 
-                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item0}.png`} onError={onErrorImg} />
-                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item1}.png`} onError={onErrorImg} />
-                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item2}.png`} onError={onErrorImg} />
-                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item3}.png`} onError={onErrorImg} />
-                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item4}.png`} onError={onErrorImg} />
-                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item5}.png`} onError={onErrorImg} />
+                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item0}.png`} onError={onErrorImg} alt={participant.item0} />
+                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item1}.png`} onError={onErrorImg} alt={participant.item1} />
+                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item2}.png`} onError={onErrorImg} alt={participant.item2} />
+                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item3}.png`} onError={onErrorImg} alt={participant.item3} />
+                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item4}.png`} onError={onErrorImg} alt={participant.item4} />
+                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item5}.png`} onError={onErrorImg} alt={participant.item5} />
                                 </div>
                             </div>
                         </div>
@@ -46,7 +47,7 @@ const MatchDetail = ({ gameData, onErrorImg }) => {
                 // 패배한 팀
                 if (participant.win === false) {           
                     return (
-                        <div className={styles[`gameData-detail-lose-container`]}>
+                        <div className={styles[`gameData-detail-lose-container`]} key={index}>
                             <div className={styles[`detail-list`]}>
                                 {/* 소환사가 플레이한 챔피언의 이미지 */}
                                 <div className={styles[`participant-img`]}>
@@ -54,6 +55,7 @@ const MatchDetail = ({ gameData, onErrorImg }) => {
                                         src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${participant.championName}.png`}
                                         className={styles['gameData-championMiniFaceImg']}
                                         onError={onErrorImg}
+                                        alt={participant.championName}
                                     />
                                 </div>
                                 {/* 소환사명 */}
@@ -68,12 +70,12 @@ const MatchDetail = ({ gameData, onErrorImg }) => {
                                 <div className={styles[`participant-total-wards-placed`]}>와드 설치 : {participant.wardsPlaced}</div>
                                 {/* 아이템이미지 */}
                                 <div className={styles[`participant-item`]}> 
-                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item0}.png`} onError={onErrorImg}/>
-                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item1}.png`} onError={onErrorImg}/>
-                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item2}.png`} onError={onErrorImg}/>
-                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item3}.png`} onError={onErrorImg}/>
-                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item4}.png`} onError={onErrorImg}/>
-                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item5}.png`} onError={onErrorImg}/>
+                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item0}.png`} onError={onErrorImg} alt={participant.item0}/>
+                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item1}.png`} onError={onErrorImg} alt={participant.item1}/>
+                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item2}.png`} onError={onErrorImg} alt={participant.item2}/>
+                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item3}.png`} onError={onErrorImg} alt={participant.item3}/>
+                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item4}.png`} onError={onErrorImg} alt={participant.item4}/>
+                                    <img src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${participant.item5}.png`} onError={onErrorImg} alt={participant.item5}/>
                                 </div>
                             </div>
                         </div>

--- a/src/components/contents/SummonerProfile.js
+++ b/src/components/contents/SummonerProfile.js
@@ -11,7 +11,7 @@ import Emblem_Grandmaster from "./../../Data/Emblems/Emblem_Grandmaster.png"
 import Emblem_Challenger from "./../../Data/Emblems/Emblem_Challenger.png"
 
 // 소환사 프로필 컴포넌트
-const SummonerProfile = ({ playerInformation, gameList, searchText, leagueList }) => {
+const SummonerProfile = ({ playerInformation, leagueList }) => {
     const emblemImgs = [{key : "IRON", Emblem : Emblem_Iron}, {key : "BRONZE", Emblem : Emblem_Bronze}, 
         {key : "SILVER", Emblem : Emblem_Silver}, {key : "GOLD", Emblem : Emblem_Gold},
         {key : "PLATINUM", Emblem : Emblem_Platinum}, {key : "DIAMOND", Emblem : Emblem_Diamond},

--- a/src/components/contents/SummonerProfile.js
+++ b/src/components/contents/SummonerProfile.js
@@ -25,6 +25,7 @@ const SummonerProfile = ({ playerInformation, gameList, searchText, leagueList }
                     <img 
                         src={`http://ddragon.leagueoflegends.com/cdn/12.21.1/img/profileicon/${playerInformation.profileIconId}.png`} 
                         id={styles["summonerProfileIcon"]}
+                        alt={playerInformation.profileIconId}
                     />
                     <div className={styles['summonerProfile-profile-userInfo']}>
                         <h3 id={styles["summonerName"]}>{playerInformation.name}</h3>
@@ -45,7 +46,9 @@ const SummonerProfile = ({ playerInformation, gameList, searchText, leagueList }
                                     {emblemImgs.map((imgList) => {
                                         if(imgList.key == list.tier) {
                                             return (
-                                                <li key={index}><img src={imgList.Emblem} className={styles['emblemImg']}/></li>
+                                                <li key={index}>
+                                                    <img src={imgList.Emblem} className={styles['emblemImg']} alt={imgList.Emblem} />
+                                                </li>
                                             )
                                         }
                                     })}
@@ -67,7 +70,7 @@ const SummonerProfile = ({ playerInformation, gameList, searchText, leagueList }
                                         if(imgList.key == list.tier) {
                                             return (
                                                 <li key={index}>
-                                                    <img src={imgList.Emblem} className={styles['emblemImg']}/>
+                                                    <img src={imgList.Emblem} className={styles['emblemImg']} alt={imgList.Emblem}/>
                                                 </li>
                                             )
                                         }

--- a/src/pages/ChampionDetailInfo.js
+++ b/src/pages/ChampionDetailInfo.js
@@ -65,6 +65,7 @@ const ChampionDetailInfo = ({
                         src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${findChampionObject.id}.png`} 
                         id={styles['championDetailInfo-img']}
                         onError={onErrorImg}
+                        alt={findChampionObject.id}
                     />
                     <h1 id={styles['champion-name']}>{findChampionObject.name}</h1>
                     <h3 id={styles['champion-title']}>{findChampionObject.title}</h3>
@@ -90,6 +91,7 @@ const ChampionDetailInfo = ({
                         src={`http://ddragon.leagueoflegends.com/cdn/12.21.1/img/passive/${passive.image?.full}`} 
                         className={styles['skillsContainer-img']}
                         onError={onErrorImg}
+                        alt={passive.image?.full}
                     />
                     {/* 패시브 이름과 설명 */}
                     <div className={styles['skillsContainer-description']}>
@@ -105,6 +107,7 @@ const ChampionDetailInfo = ({
                             src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/spell/${skill.id}.png`} 
                             className={styles['skillsContainer-img']}
                             onError={onErrorImg}
+                            alt={skill.id}
                         />
                         {/* 스킬 이름과 설명 */}
                         <div className={styles['skillsContainer-description']}>
@@ -137,6 +140,7 @@ const ChampionDetailInfo = ({
                                             <img 
                                                 src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${reco.id}.png`} 
                                                 onError={onErrorImg}
+                                                alt={reco.id}
                                             />
                                             {/* 추천아이템 이름 */}
                                             <h5>{itemName}</h5>

--- a/src/pages/ChampionInfo.js
+++ b/src/pages/ChampionInfo.js
@@ -28,6 +28,7 @@ const ChampionInfo = (
                                 src={`https://ddragon.leagueoflegends.com/cdn/12.21.1/img/champion/${championObjectArray[index].id}.png`} 
                                 className={styles['championInfo-img']}
                                 onError={onErrorImg}
+                                alt={championObjectArray[index].id}
                             />
                             <div>{championObjectArray[index].name}</div>
                         </div>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import styles from "./Home.module.css";
 import { FcSearch } from "react-icons/fc";
 import Match from '../components/contents/Match';
@@ -15,12 +15,18 @@ const Home = ({
     getPlayerLeague,
     onErrorImg,
 }) => {
+    // searchText를 새로 저장하기 위해 nickname을 만듬
+    const [nickname, setNickname] = useState('');
+
 
     // 검색버튼 onClick 함수
     const searchClick = () => {
         getPlayerInformation();
         getPlayerGames();
         getPlayerLeague();
+        // 검색할 닉네임을 타이핑하고 클릭을 누를 경우 최종 검색할 닉네임을 nickname에 저장하도록 한다.
+        // 이후 nickname값을 Match 컴포넌트에 props로 전달한다.
+        setNickname(searchText); 
     }
 
     return (
@@ -35,7 +41,7 @@ const Home = ({
                         setSearchText((prev) => {
                             return prev = encodeURIComponent(e.target.value);
                         });
-                    }} 
+                    }}
                 />
                 {/* 검색버튼 */}
                 <button onClick={searchClick} className={styles['app-searchButton']} >
@@ -48,9 +54,9 @@ const Home = ({
                 <Match 
                     playerInformation={playerInformation} 
                     gameList={gameList} 
-                    searchText={searchText} 
                     leagueList={leagueList} 
                     onErrorImg={onErrorImg}
+                    nickname={nickname}
                 />
             </div>
         </>

--- a/src/pages/ItemInfo.js
+++ b/src/pages/ItemInfo.js
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react";
+import styles from "./ItemInfo.module.css";
+import axios from "axios";
+
+const ItemInfo = ({ 
+    onErrorImg 
+}) => {
+    const [itemArray, setItemArray] = useState([]);
+
+    // 아이템 정보를 가져오는 함수
+    const getItemInfomation = () => {
+        axios.get('http://localhost:4000/item')
+        .then(response => {
+            setItemArray(Object.values(response.data.data));
+        })
+        .catch(error => console.log(error));
+    }
+
+    useEffect(() => {
+        getItemInfomation();
+        console.log(itemArray)
+    }, [])
+
+    return (
+        <>
+            <h3 className={styles['ItemInfo-title']}>아이템</h3>
+            <div className={styles['ItemInfo-container']}>
+                {itemArray.map(it => (
+                    <div className={styles['ItemInfo-item']}>
+                        <img 
+                            src={`https://ddragon.leagueoflegends.com/cdn/12.12.1/img/item/${it.image.full}`} 
+                            onError={onErrorImg} 
+                            alt={it.name} 
+                            className={styles['item-img']}
+                        />
+                        <h4>{it.name}</h4>
+                        {/* TODO: 아이템 상세컴포넌트 개발 후 링크 연결하기 */}
+                    </div>
+                ))}
+            </div>
+        </>
+    )
+}
+
+export default ItemInfo;

--- a/src/pages/ItemInfo.module.css
+++ b/src/pages/ItemInfo.module.css
@@ -1,0 +1,31 @@
+.ItemInfo-title {
+    text-align: center;
+    border: 1px dotted rgb(206, 202, 202);
+    margin: auto;
+    padding: 40px;
+    font-size: 25px;
+    background: linear-gradient(to right, rgb(157, 225, 241), rgb(182, 226, 240));
+}
+
+.ItemInfo-container {
+    text-align: center;
+    background: linear-gradient(to right, rgb(126, 216, 238), rgb(214, 232, 238));
+    display : grid;
+    grid-template-columns: repeat(6, 1fr);
+    grid-auto-rows: 150px;
+    grid-gap: 20px;
+    padding: 30px;
+}
+
+.ItemInfo-item {
+    background-color: rgb(243, 241, 241);
+    padding: 28px 0;
+    box-shadow: 0 0 5px 1px rgb(66 152 173);
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.item-img {
+    width: 60px;
+    height: 60px;
+}


### PR DESCRIPTION
전적검색 결과 출력 후 검색텍스트를 지울 때 이전 검색 결과가 변경되는 현상을 수정함.

1. 기존에는 searchText값을 가지고 전적결과를 출력했는데 이 값은 input창의 값이 변경될 경우 이전의 검색결과도 같이 변경되는 문제가 있었음.
2. 따라서 검색창에 닉네임을 입력하고 클릭을 했을 경우에, 최종적으로 검색창에 입력된 값을 nickname이라는 새 state에 저장하여 Match컴포넌트의 props로 전달하도록 하였음.
3. 기존의 searchText가 아닌 최종적으로 검색할 닉네임을 담고 있는 nickname이라는 state를 통해서 전적결과를 출력하도록 변경하였음.
4. 추가적으로 컴포넌트간에 전달되는 props값 중 사용하지 않는 값은 제거함. 

아이템 정보 탭 및 페이지 구현

1.  상단 Header에 '아이템정보' 탭을 추가한 후 아이템정보컴포넌트를 생성 후 연결함.